### PR TITLE
Remove CodeClimate steps from appveyor.yml

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,8 +6,6 @@ configuration: Release
 environment:
   CODACY_PROJECT_TOKEN:
     secure: 8fnQaRryh/pMRB9NtqyX0M0FSfPYW8Rtl1zeYcMXLVaK0o1UC3EAynZSB6rze5wM
-  CODECLIMATE_TOKEN:
-    secure: OYnZbQvxEZxr+V1o2dQPmuoHSq3szKIEd+pMsXaZJY/sePzo+aDODoWsJdcRWftkTTzcfT2oZdB45q43WImHnNvE1cx8pXPx1IcZpOEAo4I=
 
 dotnet_csproj:
   patch: true
@@ -44,7 +42,6 @@ before_build:
   - cmd: choco install opencover.portable
   - cmd: choco install codecov
   - cmd: curl -L https://github.com/codacy/codacy-coverage-reporter/releases/latest/download/codacy-coverage-reporter-assembly.jar > ./codacy-test-reporter.jar
-  - cmd: curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-windows-amd64 > codeclimate-test-reporter.exe
   - cmd: dotnet tool install --global dotnet-sonarscanner
 
 build: off
@@ -58,7 +55,6 @@ build_script:
   - ps: if(-Not $env:APPVEYOR_PULL_REQUEST_NUMBER) { $Params += "/d:sonar.branch.name=`"$env:APPVEYOR_REPO_BRANCH`"" }
   - ps: if($env:APPVEYOR_PULL_REQUEST_NUMBER) { $Params += "/d:sonar.pullrequest.key=$env:APPVEYOR_PULL_REQUEST_NUMBER", "/d:sonar.pullrequest.branch=`"$env:APPVEYOR_REPO_BRANCH`"" }
   - ps: Start-process "dotnet" "sonarscanner begin $($Params -join ' ')"
-  - codeclimate-test-reporter before-build
   - dotnet build --verbosity minimal %SOLUTION_NAME%.sln
   - ps: $TEST_PROJECTS = (Get-ChildItem -Path .\Tests\**\ -Recurse -Include *.csproj).Fullname
   - ps: |
@@ -70,8 +66,6 @@ build_script:
           $wc.UploadFile("https://ci.appveyor.com/api/testresults/xunit/$($env:APPVEYOR_JOB_ID)", (Resolve-Path $path/test-results.xml))          
       }
   - if %LOCAL_PR% EQU 1 codecov -f "Tests\%SOLUTION_NAME%.Tests\coverage.net8.0.opencover.xml"
-  - if %LOCAL_PR% EQU 1 codeclimate-test-reporter format-coverage -t lcov -o "Tests\%SOLUTION_NAME%.Tests\code-climate.json" "Tests\%SOLUTION_NAME%.Tests\coverage.net8.0.info"
-  - if %LOCAL_PR% EQU 1 codeclimate-test-reporter upload-coverage -i "Tests\%SOLUTION_NAME%.Tests\code-climate.json" -r %CODECLIMATE_TOKEN%
   - if %LOCAL_PR% EQU 1 java -jar ./codacy-test-reporter.jar report -l CSharp -t %CODACY_PROJECT_TOKEN% -r "Tests\%SOLUTION_NAME%.Tests\coverage.net8.0.opencover.xml"
   - if %LOCAL_PR% EQU 1 dotnet sonarscanner end /d:sonar.token="%SONAR_TOKEN%"
 


### PR DESCRIPTION
## 📑 Description
Remove CodeClimate steps from appveyor.yml

## ✅ Checks
- [X] My pull request adheres to the code style of this project
- [X] My code requires changes to the documentation
- [X] I have updated the documentation as required
- [X] All the tests have passed

## ☢️ Does this introduce a breaking change?
- [ ] Yes
- [X] No

---

## Summary by Sourcery

Remove CodeClimate integration from the AppVeyor CI configuration.

Chores:
- Delete the CODECLIMATE_TOKEN environment variable from appveyor.yml
- Remove the commands that download and invoke the CodeClimate test reporter in the before_build and build_script sections

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI


### What change is being made?

Remove CodeClimate steps from the `appveyor.yml` configuration file.

### Why are these changes being made?

The CodeClimate steps are being removed as they are no longer needed for the project's continuous integration process, possibly due to a shift to using alternative tools for code coverage reporting like Codacy. Removing these steps simplifies the CI configuration and avoids using unnecessary tokens, ensuring a more streamlined and secure setup.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed integration with Code Climate test reporter from the CI configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->